### PR TITLE
Positive amount enforcement and limit balance

### DIFF
--- a/Woolong/Woolong.cs
+++ b/Woolong/Woolong.cs
@@ -107,7 +107,7 @@ namespace Woolong
             BigInteger nTargetValue = BytesToInt(targetValue) + amount;
             
             if (nOriginatorValue >= 0 &&
-                 amount >= 0)
+                 amount > 0)
             {
                 Storage.Put(Storage.CurrentContext, originator, IntToBytes(nOriginatorValue));
                 Storage.Put(Storage.CurrentContext, to, IntToBytes(nTargetValue));
@@ -143,8 +143,8 @@ namespace Woolong
             var toValInt = BytesToInt(Storage.Get(Storage.CurrentContext, to));
  
             if (fromValInt >= amount &&
-                amount >= 0  &&
-                allValInt >= 0)
+                amount > 0  &&
+                allValInt >= amount)
             {
                 Storage.Put(Storage.CurrentContext, from.Concat(originator), IntToBytes(allValInt - amount));
                 Storage.Put(Storage.CurrentContext, to, IntToBytes(toValInt + amount));


### PR DESCRIPTION
For the two transfer function functions (transfer and transferfrom), the amount should be >0.
Also, for the transferfrom function, there is an agreed balance that can be spent on behalf of the from actor. This should be greater in value than the amount, otherwise you overspend the agreed limit.

Those are the two changes.